### PR TITLE
Add basic logic to get MZ for a hosts parent domain

### DIFF
--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/slice"
-	v1alpha1 "github.com/Kuadrant/multi-cluster-traffic-controller/pkg/apis/v1alpha1"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/apis/v1alpha1"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/syncer"
 	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/traffic"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,6 +47,7 @@ const (
 type HostService interface {
 	CreateDNSRecord(ctx context.Context, hostKey string, managedZone *v1alpha1.ManagedZone) (*v1alpha1.DNSRecord, error)
 	GetManagedZone(ctx context.Context, t traffic.Interface) (*v1alpha1.ManagedZone, error)
+	GetManagedZoneForDomain(ctx context.Context, domain string, t traffic.Interface) (*v1alpha1.ManagedZone, error)
 	AddEndPoints(ctx context.Context, t traffic.Interface) error
 	RemoveEndpoints(ctx context.Context, t traffic.Interface) error
 }
@@ -208,7 +209,16 @@ func (r *GatewayReconciler) reconcileGateway(ctx context.Context, previous gatew
 
 		if hasAttachedRoutes {
 			hasAnyAttachedRoutes = true
-			managedZone, err := r.Host.GetManagedZone(ctx, trafficAccessor)
+
+			hostParts := strings.SplitN(host, ".", 2)
+			if len(hostParts) < 2 {
+				continue
+			}
+			subDomain := hostParts[0]
+			parentDomain := hostParts[1]
+
+			log.V(2).Info("getting managed zone for parent domain of host", "host", host, "parentDomain", parentDomain, "subDomain", subDomain)
+			managedZone, err := r.Host.GetManagedZoneForDomain(ctx, parentDomain, trafficAccessor)
 			if err != nil {
 				return metav1.ConditionUnknown, clusters, false, err
 			}
@@ -218,7 +228,7 @@ func (r *GatewayReconciler) reconcileGateway(ctx context.Context, previous gatew
 			}
 			// TODO: ownerRefs e.g.
 			// err = controllerutil.SetControllerReference(parentZone, nsRecord, r.Scheme)
-			record, err := r.Host.CreateDNSRecord(ctx, host, managedZone)
+			record, err := r.Host.CreateDNSRecord(ctx, subDomain, managedZone)
 			if err != nil {
 				log.Error(err, "failed to register host ")
 				return metav1.ConditionUnknown, clusters, false, err


### PR DESCRIPTION
Updates the gateway dns record creation logic to look for a ManagedZone for each hosts parent domain i.e host = apps.dev.hcpapps.net, parent domain = dev.hcpapps.net.  This will first look for a matching zone in the gateways own namespace, and then fallback to look in the default ctrl namespace (multi-cluster-traffic-controller-system). If none is found, the host is ignored.