### PR TITLE
#85: Reconcile Gateway from watching cluster secret

### DIFF
--- a/config/syncer-control/kustomization.yaml
+++ b/config/syncer-control/kustomization.yaml
@@ -1,0 +1,10 @@
+# Resources to be created in the tenant namespace in the control plane
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- role.yaml
+- rolebinding.yaml
+- serviceaccount.yaml
+
+namespace: tenant

--- a/config/syncer-control/role.yaml
+++ b/config/syncer-control/role.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: syncer
+  namespace: system
+rules:
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - update
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/syncer-control/rolebinding.yaml
+++ b/config/syncer-control/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: syncer
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syncer
+subjects:
+- kind: ServiceAccount
+  name: syncer
+  namespace: system

--- a/config/syncer-control/serviceaccount.yaml
+++ b/config/syncer-control/serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: syncer
+  namespace: system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: syncer-token
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: syncer
+type: kubernetes.io/service-account-token  

--- a/config/syncer/.gitignore
+++ b/config/syncer/.gitignore
@@ -1,0 +1,1 @@
+secret.yaml

--- a/config/syncer/kustomization.yaml
+++ b/config/syncer/kustomization.yaml
@@ -5,9 +5,19 @@ resources:
 - serviceaccount.yaml
 - rolebinding.yaml
 - syncer.yaml
+- secret.yaml
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: syncer
   newName: syncer
   newTag: latest
+
+patches:
+- path: syncer_parameter_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: sync-agent

--- a/config/syncer/syncer_parameter_patch.json
+++ b/config/syncer/syncer_parameter_patch.json
@@ -1,0 +1,12 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/args/3",
+    "value": "--control-plane-namespace"
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/args/4",
+    "value": ""
+  }
+]

--- a/hack/.clusterUtils
+++ b/hack/.clusterUtils
@@ -1,22 +1,15 @@
 # shellcheck shell=bash
 
-makeSecretForCluster() {
-  local clusterName=$1
-  local targetCluster=$2
+makeSecretForKubeconfig() {
+  local kubeconfig=$1
+  local clusterName=$2
+  local targetCluster=$3
   local targetClusterName=${targetCluster:=$clusterName}
-  local localAccess=${3}
 
-  if [ "$localAccess" != "true" ]; then
-    internalFlag="--internal"
-  fi
-
-  local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
-  ${KIND_BIN} export kubeconfig -q $internalFlag --name ${clusterName} --kubeconfig ${tmpfile}
-  local server=$(kubectl --kubeconfig ${tmpfile} config view -o jsonpath="{$.clusters[?(@.name == 'kind-${clusterName}')].cluster.server}")
-  local caData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.clusters[?(@.name == 'kind-${clusterName}')].cluster.certificate-authority-data}")
-  local certData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${clusterName}')].user.client-certificate-data}")
-  local keyData=$(kubectl --kubeconfig ${tmpfile} config view --raw -o jsonpath="{$.users[?(@.name == 'kind-${clusterName}')].user.client-key-data}")
-  rm -f ${tmpfile}
+  local server=$(kubectl --kubeconfig ${kubeconfig} config view -o jsonpath="{$.clusters[?(@.name == '${clusterName}')].cluster.server}")
+  local caData=$(kubectl --kubeconfig ${kubeconfig} config view --raw -o jsonpath="{$.clusters[?(@.name == '${clusterName}')].cluster.certificate-authority-data}")
+  local certData=$(kubectl --kubeconfig ${kubeconfig} config view --raw -o jsonpath="{$.users[?(@.name == '${clusterName}')].user.client-certificate-data}")
+  local keyData=$(kubectl --kubeconfig ${kubeconfig} config view --raw -o jsonpath="{$.users[?(@.name == '${clusterName}')].user.client-key-data}")
 
   cat <<EOF
 kind: Secret
@@ -39,6 +32,24 @@ stringData:
   server: ${server}
 type: Opaque
 EOF
+
+}
+
+makeSecretForCluster() {
+  local clusterName=$1
+  local targetCluster=$2
+  local targetClusterName=${targetCluster:=$clusterName}
+  local localAccess=${3}
+
+  if [ "$localAccess" != "true" ]; then
+    internalFlag="--internal"
+  fi
+
+  local tmpfile=$(mktemp /tmp/kubeconfig-internal.XXXXXX)
+  ${KIND_BIN} export kubeconfig -q $internalFlag --name ${clusterName} --kubeconfig ${tmpfile}
+
+  makeSecretForKubeconfig $tmpfile kind-$clusterName $targetCluster $targetClusterName
+  rm -f $tmpfile
 }
 
 setNamespacedName() {
@@ -51,4 +62,14 @@ setLabel() {
   label=$1
   value=$2
   cat /dev/stdin | ${YQ_BIN} '.metadata.labels."'$label'"="'$value'"'
+}
+
+setConfig() {
+  expr=$1
+
+  cp /dev/stdin /tmp/doctmp
+  config=$(cat /tmp/doctmp | ${YQ_BIN} '.stringData.config')
+  updatedConfig=$(echo $config | ${YQ_BIN} -P $expr -o=json)
+
+  cat /tmp/doctmp | cfg=$updatedConfig ${YQ_BIN} '.stringData.config=strenv(cfg)'
 }

--- a/hack/.kindUtils
+++ b/hack/.kindUtils
@@ -27,4 +27,5 @@ nodes:
 EOF
 mkdir -p ./tmp/kubeconfigs
 ${KIND_BIN} get kubeconfig --name ${cluster} > ./tmp/kubeconfigs/${cluster}.kubeconfig
+${KIND_BIN} export kubeconfig --name ${cluster} --kubeconfig ./tmp/kubeconfigs/internal/${cluster}.kubeconfig --internal
 }

--- a/hack/register-cluster.sh
+++ b/hack/register-cluster.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+### Usage
+### export KUBECONFIG=$(pwd)/tmp/kubeconfigs/mctc-control-plane.kubeconfig
+### register-cluster.sh <PATH TO CONTROL CLUSTER KUBECONFIG> <PATH TO TENANT CLUSTER KUBECONFIG> <TENANT NAMESPACE> <NAME OF THE TENANT CLUSTER> > agent-manifests.yaml
+###
+### Outputs the manifests to deploy the syncer in the tenant cluster
+
+LOCAL_SETUP_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${LOCAL_SETUP_DIR}"/.setupEnv
+source "${LOCAL_SETUP_DIR}"/.clusterUtils
+source "${LOCAL_SETUP_DIR}"/.argocdUtils
+
+controlClusterKubeconfig=$1
+clusterKubeconfig=$2
+tenantNs=$3
+clusterName=$4
+
+# Validate that Gateway API is installed in the tenant cluster
+if ! kubectl --kubeconfig $clusterKubeconfig get crd/gateways.gateway.networking.k8s.io > /dev/null ; then
+  echo "Gateway API not found in tenant cluster" > /dev/stderr
+  exit 1
+fi
+
+# Create ArgoCD secret for cluster in control plane
+makeSecretForKubeconfig $clusterKubeconfig $clusterName |
+setNamespacedName argocd $clusterName |
+setLabel argocd.argoproj.io/secret-type cluster |
+kubectl apply -f - > /dev/null
+
+# Create SA in tenant ns
+cd ${LOCAL_SETUP_DIR}/../config/syncer-control
+${KUSTOMIZE_BIN} edit set namespace $tenantNs
+${KUSTOMIZE_BIN} build . | kubectl apply -f - > /dev/null
+cd ../../
+
+# Get the token for the SA
+export saToken=$(kubectl get secret/syncer-token -n $tenantNs -o go-template="{{.data.token | base64decode}}")
+
+
+# Create secret to access control cluster in workload cluster
+makeSecretForKubeconfig $controlClusterKubeconfig kind-mctc-control-plane $clusterName |
+setNamespacedName mctc-system control-plane-cluster-internal |
+setLabel argocd.argoproj.io/secret-type cluster |
+setConfig '.bearerToken=strenv(saToken)' > ${LOCAL_SETUP_DIR}/../config/syncer/secret.yaml
+
+# Set the --control-plane-namespace flag in the agent deployment to the tenant
+# namespace
+${YQ_BIN} -i -P -o=json '.[1].value = "'$tenantNs'"' ${LOCAL_SETUP_DIR}/../config/syncer/syncer_parameter_patch.json
+
+# Output deployment manifests
+${KUSTOMIZE_BIN} build ${LOCAL_SETUP_DIR}/../config/syncer

--- a/pkg/_internal/clusterSecret/util.go
+++ b/pkg/_internal/clusterSecret/util.go
@@ -1,0 +1,14 @@
+package clusterSecret
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func IsClusterSecret(object metav1.Object) bool {
+	secretType, ok := object.GetLabels()["argocd.argoproj.io/secret-type"]
+	if !ok {
+		return false
+	}
+
+	return secretType == "cluster"
+}

--- a/pkg/_internal/slice/slice.go
+++ b/pkg/_internal/slice/slice.go
@@ -41,3 +41,14 @@ func Find[T any](slice []T, predicate func(T) bool) (element T, ok bool) {
 
 	return
 }
+
+func Filter[T any](slice []T, predicate func(T) bool) []T {
+	result := []T{}
+	for _, elem := range slice {
+		if predicate(elem) {
+			result = append(result, elem)
+		}
+	}
+
+	return result
+}

--- a/pkg/controllers/gateway/cluster_eventhandler.go
+++ b/pkg/controllers/gateway/cluster_eventhandler.go
@@ -1,0 +1,79 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/clusterSecret"
+	"github.com/Kuadrant/multi-cluster-traffic-controller/pkg/_internal/slice"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+type ClusterEventHandler struct {
+	client client.Client
+}
+
+var _ handler.EventHandler = &ClusterEventHandler{}
+
+// Create implements handler.EventHandler
+func (eh *ClusterEventHandler) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.Object, q)
+}
+
+// Delete implements handler.EventHandler
+func (eh *ClusterEventHandler) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.Object, q)
+}
+
+// Generic implements handler.EventHandler
+func (eh *ClusterEventHandler) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.Object, q)
+}
+
+// Update implements handler.EventHandler
+func (eh *ClusterEventHandler) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	eh.enqueueForObject(e.ObjectNew, q)
+}
+
+func (eh *ClusterEventHandler) enqueueForObject(obj v1.Object, q workqueue.RateLimitingInterface) {
+	if !clusterSecret.IsClusterSecret(obj) {
+		return
+	}
+
+	gateways, err := eh.getGatewaysFor(obj.(*corev1.Secret))
+	if err != nil {
+		log.Log.Error(err, "failed to get gateways when enqueueing from cluster secret")
+		return
+	}
+
+	for _, gateway := range gateways {
+		log.Log.Info(fmt.Sprintf("Enqueing reconciliation from secret update to gateway/%s", gateway.Name))
+		q.Add(ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(&gateway),
+		})
+	}
+}
+
+func (eh *ClusterEventHandler) getGatewaysFor(secret *corev1.Secret) ([]gatewayv1beta1.Gateway, error) {
+	clusterConfig, err := clusterSecret.ClusterConfigFromSecret(secret)
+	if err != nil {
+		return nil, err
+	}
+
+	gateways := &gatewayv1beta1.GatewayList{}
+	if err := eh.client.List(context.TODO(), gateways); err != nil {
+		return nil, err
+	}
+
+	return slice.Filter(gateways.Items, func(gateway gatewayv1beta1.Gateway) bool {
+		return slice.ContainsString(selectClusters(gateway), clusterConfig.Name)
+	}), nil
+}

--- a/pkg/controllers/gateway/gateway_controller.go
+++ b/pkg/controllers/gateway/gateway_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -342,8 +343,15 @@ func selectClusters(gateway gatewayv1beta1.Gateway) []string {
 func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1beta1.Gateway{}).
+		Watches(&source.Kind{
+			Type: &corev1.Secret{},
+		}, &ClusterEventHandler{client: r.Client}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			gateway := object.(*gatewayv1beta1.Gateway)
+			gateway, ok := object.(*gatewayv1beta1.Gateway)
+			if !ok {
+				return true
+			}
+
 			return slice.ContainsString(getSupportedClasses(), string(gateway.Spec.GatewayClassName))
 		})).
 		Complete(r)


### PR DESCRIPTION
## Description

> Closes #85

Add a watch for secrets in the Gateway controller that will enqueue gateways if there's a change in the related cluster secret

## Verification steps

1. For testing purposes, as #52 is not done, update [this line of code](https://github.com/david-martin/multi-cluster-traffic-controller/blob/8bb9849ad642abdc847d5995ea34f3d07a187b17/pkg/controllers/gateway/gateway_controller.go#L337) to the following:
    ```go
    return []string{"mctc-workload-1"}
    ```

1. Run local-setup and start the controller

1. Create a sample gateway

1. Update the secret for the workload cluster

1. Verify that the sample gateway is reconciled 
